### PR TITLE
Attribute matches exact.

### DIFF
--- a/R/labelled.R
+++ b/R/labelled.R
@@ -40,7 +40,7 @@ labelled <- haven::labelled
 #' @rdname labelled
 #' @inheritParams haven::is.labelled
 #' @importFrom haven is.labelled
-#' @seealso \code{\link[haven]{is.labelled}} (\pkg{haven})
+#' @seealso \code{\link[haven:labelled]{haven::is.labelled()}} (\pkg{haven})
 #' @export
 #' @examples
 #' is.labelled(s1)

--- a/R/retrocompatibility.R
+++ b/R/retrocompatibility.R
@@ -26,13 +26,13 @@ update_labelled.default <- function(x) {
 #' @export
 update_labelled.labelled <- function(x) {
   # update only previous labelled class, but not objects from Hmisc
-  if (!is.null(attr(x, "labels"))) {
-    if (is.null(attr(x, "na_values")) & is.null(attr(x, "na_range"))) {
-      x <- labelled(x, labels = attr(x, "labels"), label = attr(x, "label"))
+  if (!is.null(attr(x, "labels", exact = TRUE))) {
+    if (is.null(attr(x, "na_values", exact = TRUE)) & is.null(attr(x, "na_range", exact = TRUE))) {
+      x <- labelled(x, labels = attr(x, "labels", exact = TRUE), label = attr(x, "label", exact = TRUE))
     } else {
       x <- labelled_spss(
-        x, na_values = attr(x, "na_values"), na_range = attr(x, "range"),
-        labels = attr(x, "labels"), label = attr(x, "label")
+        x, na_values = attr(x, "na_values", exact = TRUE), na_range = attr(x, "range", exact = TRUE),
+        labels = attr(x, "labels", exact = TRUE), label = attr(x, "label", exact = TRUE)
       )
     }
   }


### PR DESCRIPTION
Attributes should be matched exactly `attr(x, which, exact = TRUE)` in order to not produce bad behaviours. Mainly, when looking for `attr(x, "label")`, if there is no attribute `label`, it matches attribute `labels`, producing an error when calling to the `labelled` function:
``Error: `label` must be a character vector of length one``