### PR TITLE
Use attr(..., exact = TRUE) in update_labelled()

### DIFF
--- a/R/retrocompatibility.R
+++ b/R/retrocompatibility.R
@@ -26,13 +26,13 @@ update_labelled.default <- function(x) {
 #' @export
 update_labelled.labelled <- function(x) {
   # update only previous labelled class, but not objects from Hmisc
-  if (!is.null(attr(x, "labels"))) {
-    if (is.null(attr(x, "na_values")) & is.null(attr(x, "na_range"))) {
-      x <- labelled(x, labels = attr(x, "labels"), label = attr(x, "label"))
+  if (!is.null(attr(x, "labels", exact = TRUE))) {
+    if (is.null(attr(x, "na_values", exact = TRUE)) & is.null(attr(x, "na_range", exact = TRUE))) {
+      x <- labelled(x, labels = attr(x, "labels", exact = TRUE), label = attr(x, "label", exact = TRUE))
     } else {
       x <- labelled_spss(
-        x, na_values = attr(x, "na_values"), na_range = attr(x, "range"),
-        labels = attr(x, "labels"), label = attr(x, "label")
+        x, na_values = attr(x, "na_values", exact = TRUE), na_range = attr(x, "range", exact = TRUE),
+        labels = attr(x, "labels", exact = TRUE), label = attr(x, "label", exact = TRUE)
       )
     }
   }

--- a/man/labelled.Rd
+++ b/man/labelled.Rd
@@ -56,5 +56,5 @@ is.labelled(s1)
 \seealso{
 \code{\link[haven]{labelled}} (\pkg{haven})
 
-\code{\link[haven]{is.labelled}} (\pkg{haven})
+\code{\link[haven:labelled]{haven::is.labelled()}} (\pkg{haven})
 }

--- a/man/to_character.Rd
+++ b/man/to_character.Rd
@@ -20,7 +20,7 @@ to_character(x, ...)
 \item{nolabel_to_na}{Should values with no label be converted to `NA`?}
 }
 \description{
-By default, \code{to_character} is a wrapper for \code{\link[base]{as.character}}.
+By default, \code{to_character} is a wrapper for \code{\link[base:character]{base::as.character()}}.
 For labelled vector, to_character allows to specify if value, labels or labels prefixed
 with values should be used for conversion.
 }

--- a/man/to_factor.Rd
+++ b/man/to_factor.Rd
@@ -48,8 +48,8 @@ convert to a character or a numeric factor?}
 \item{labelled_only}{for a data.frame, convert only labelled variables to factors?}
 }
 \description{
-The base function \code{\link[base]{as.factor}} is not a generic, but this variant
-is. By default, \code{to_factor} is a wrapper for \code{\link[base]{as.factor}}.
+The base function \code{\link[base:factor]{base::as.factor()}} is not a generic, but this variant
+is. By default, \code{to_factor} is a wrapper for \code{\link[base:factor]{base::as.factor()}}.
 Please note that \code{to_factor} differs slightly from \code{\link[haven]{as_factor}}
 method provided by \code{haven} package.
 }


### PR DESCRIPTION
Attributes should be matched exactly `attr(x, which, exact = TRUE)` in order to not produce bad behaviours. Mainly, when looking for `attr(x, "label")`, if there is no attribute `label`, it matches attribute `labels`, producing an error when calling to the `labelled` function:
``Error: `label` must be a character vector of length one``.

Other updates in order to avoid some warnings when installing the package.