### PR TITLE
better implementation of `look_for()` when no keyword is provided

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 # labelled (development version)
 
 * bug fix in `user_na_to_tagged_na()` (#114)
+* better implementation of `look_for()` when no keyword is provided (#116)
 
 # labelled 2.9.0
 

--- a/R/lookfor.R
+++ b/R/lookfor.R
@@ -114,28 +114,31 @@ look_for <- function(data,
   if(!length(n)) stop("there are no names to search in that object")
   # search function
   keywords <- c(...)
-  if(is.null(keywords)) keywords <- names(data)
-  look <- function(x) { grep(paste(keywords, collapse="|"), x, ignore.case = ignore.case) }
-  # names search
-  x <- look(n)
-  variable <- n[x]
-  # variable labels
   l <- unlist(var_label(data))
-  if(length(l) > 0 & labels) {
-    # search labels
-    y <- look(l)
-    variable <- unique(c(variable, names(l[y])))
-  }
-  if (values) {
-    # search factor levels
-    fl <- lapply(data, levels)
-    y <- look(fl)
-    variable <- unique(c(variable, names(fl[y])))
+  if(!is.null(keywords)) {
+    look <- function(x) { grep(paste(keywords, collapse="|"), x, ignore.case = ignore.case) }
+    # names search
+    x <- look(n)
+    variable <- n[x]
+    # variable labels
+    if(length(l) > 0 & labels) {
+      # search labels
+      y <- look(l)
+      variable <- unique(c(variable, names(l[y])))
+    }
+    if (values) {
+      # search factor levels
+      fl <- lapply(data, levels)
+      y <- look(fl)
+      variable <- unique(c(variable, names(fl[y])))
 
-    # search value levels
-    vl <- lapply(data, val_labels)
-    y <- look(vl)
-    variable <- unique(c(variable, names(vl[y])))
+      # search value levels
+      vl <- lapply(data, val_labels)
+      y <- look(vl)
+      variable <- unique(c(variable, names(vl[y])))
+    }
+  } else {
+    variable <- n
   }
 
   # output

--- a/tests/testthat/test_lookfor.R
+++ b/tests/testthat/test_lookfor.R
@@ -32,6 +32,13 @@ test_that("look_for works with a single keyword.", {
 
 })
 
+test_that("look_for works with no single keyword.", {
+  expect_equal(
+    look_for(iris, details = TRUE)$variable,
+    names(iris)
+  )
+})
+
 test_that("look_for works with a regular expression", {
   lfi  <-  look_for(iris, "s")
   expect_identical(look_for(iris, "sepal|species"), lfi)


### PR DESCRIPTION
fix #116