### PR TITLE
Improve error messages for missing variable names

### DIFF
--- a/R/na_values.R
+++ b/R/na_values.R
@@ -126,8 +126,10 @@ na_values.data.frame <- function(x) {
     })
   }
 
-  if (!all(names(value) %in% names(x)))
-    stop("some variables not found in x")
+  if (!all(names(value) %in% names(x))) {
+    missing_names <- stringr::str_c(setdiff(names(value), names(x)), collapse = ", ")
+    stop("some variables not found in x:", missing_names)
+  }
 
   for (var in names(value)) if (!is.null(value[[var]])) {
     if (mode(x[[var]]) != mode(value[[var]]))
@@ -209,8 +211,10 @@ na_range.data.frame <- function(x) {
     })
   }
 
-  if (!all(names(value) %in% names(x)))
-    stop("some variables not found in x")
+  if (!all(names(value) %in% names(x))) {
+    missing_names <- stringr::str_c(setdiff(names(value), names(x)), collapse = ", ")
+    stop("some variables not found in x:", missing_names)
+  }
 
   for (var in names(value)) if (!is.null(value[[var]])) {
     if (mode(x[[var]]) != mode(value[[var]]))
@@ -259,8 +263,10 @@ set_na_values <- function(.data, ..., .values = NA, .strict = TRUE) {
     na_values(.data) <- .values
   }
   values <- rlang::dots_list(...)
-  if (.strict & !all(names(values) %in% names(.data)))
-    stop("some variables not found in .data")
+  if (.strict & !all(names(values) %in% names(.data))) {
+    missing_names <- stringr::str_c(setdiff(names(values), names(.data)), collapse = ", ")
+    stop("some variables not found in .data: ", missing_names)
+  }
 
   for (v in intersect(names(values), names(.data)))
     na_values(.data[[v]]) <- values[[v]]

--- a/R/val_labels.R
+++ b/R/val_labels.R
@@ -112,8 +112,10 @@ val_labels.data.frame <- function(x, prefixed = FALSE) {
     })
   }
 
-  if (!all(names(value) %in% names(x)))
-    stop("some variables not found in x")
+  if (!all(names(value) %in% names(x))) {
+    missing_names <- stringr::str_c(setdiff(names(value), names(x)), collapse = ", ")
+    stop("some variables not found in x:", missing_names)
+  }
 
   for (var in names(value)) if (!is.null(value[[var]])) {
     if (mode(x[[var]]) != mode(value[[var]]))
@@ -287,8 +289,10 @@ set_value_labels <- function(.data, ..., .labels = NA, .strict = TRUE) {
     val_labels(.data) <- .labels
   }
   values <- rlang::dots_list(...)
-  if (.strict & !all(names(values) %in% names(.data)))
-    stop("some variables not found in .data")
+  if (.strict & !all(names(values) %in% names(.data))) {
+    missing_names <- stringr::str_c(setdiff(names(values), names(.data)), collapse = ", ")
+    stop("some variables not found in .data: ", missing_names)
+  }
 
   for (v in intersect(names(values), names(.data)))
     val_labels(.data[[v]]) <- values[[v]]
@@ -300,8 +304,10 @@ set_value_labels <- function(.data, ..., .labels = NA, .strict = TRUE) {
 #' @export
 add_value_labels <- function(.data, ..., .strict = TRUE) {
   values <- rlang::dots_list(...)
-  if (.strict & !all(names(values) %in% names(.data)))
-    stop("some variables not found in .data")
+  if (.strict & !all(names(values) %in% names(.data))) {
+    missing_names <- stringr::str_c(setdiff(names(values), names(.data)), collapse = ", ")
+    stop("some variables not found in .data: ", missing_names)
+  }
 
   for(v in values)
     if (is.null(names(v)) | any(names(v) == ""))
@@ -318,8 +324,10 @@ add_value_labels <- function(.data, ..., .strict = TRUE) {
 #' @export
 remove_value_labels <- function(.data, ..., .strict = TRUE) {
   values <- rlang::dots_list(...)
-  if (.strict & !all(names(values) %in% names(.data)))
-    stop("some variables not found in .data")
+  if (.strict & !all(names(values) %in% names(.data)))  {
+    missing_names <- stringr::str_c(setdiff(names(values), names(.data)), collapse = ", ")
+    stop("some variables not found in .data: ", missing_names)
+  }
 
   for (v in intersect(names(values), names(.data)))
     for (l in values[[v]])

--- a/R/var_label.R
+++ b/R/var_label.R
@@ -90,8 +90,10 @@ var_label.data.frame <- function(x, unlist = FALSE) {
     })
   }
 
-  if (!all(names(value) %in% names(x)))
-    stop("some variables not found in x")
+  if (!all(names(value) %in% names(x))) {
+    missing_names <- stringr::str_c(setdiff(names(value), names(x)), collapse = ", ")
+    stop("some variables not found in x:", missing_names)
+  }
 
   value <- value[names(value) %in% names(x)]
   for (var in names(value)) var_label(x[[var]]) <- value[[var]]
@@ -152,8 +154,10 @@ set_variable_labels <- function(.data, ..., .labels = NA, .strict = TRUE) {
   }
   values <- rlang::dots_list(...)
   if (length(values) > 0) {
-    if (.strict & !all(names(values) %in% names(.data)))
-      stop("some variables not found in .data")
+    if (.strict & !all(names(values) %in% names(.data))) {
+      missing_names <- stringr::str_c(setdiff(names(values), names(.data)), collapse = ", ")
+      stop("some variables not found in .data: ", missing_names)
+    }
 
     for (v in intersect(names(values), names(.data)))
       var_label(.data[[v]]) <- values[[v]]


### PR DESCRIPTION
This PR adds the name of a missing variable to error messages:

ibrary(labelled)
iris %>% set_variable_labels(foo = "bar", baz = "asdf")
#> Error in set_variable_labels(., foo = "bar", baz = "asdf"): some variables not found in .data: foo, baz

Rather than

ibrary(labelled)
iris %>% set_variable_labels(foo = "bar", baz = "asdf")
#> Error in set_variable_labels(., foo = "bar", baz = "asdf"): some variables not found in .data