### PR TITLE
bug fix in `unlabelled()` for classic vectors, now remained unchanged

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -1,9 +1,5 @@
 # Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
 # Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
-#
-# NOTE: This workflow is overkill for most R packages and
-# check-standard.yaml is likely a better choice.
-# usethis::use_github_action("check-standard") will install it.
 on:
   push:
     branches: [main, master]
@@ -22,26 +18,18 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - {os: macOS-latest,   r: 'release'}
-
+          - {os: macos-latest,   r: 'release'}
           - {os: windows-latest, r: 'release'}
-          # Use 3.6 to trigger usage of RTools35
-          - {os: windows-latest, r: '3.6'}
-
-          # Use older ubuntu to maximise backward compatibility
-          - {os: ubuntu-18.04,   r: 'devel', http-user-agent: 'release'}
-          - {os: ubuntu-18.04,   r: 'release'}
-          - {os: ubuntu-18.04,   r: 'oldrel-1'}
-          - {os: ubuntu-18.04,   r: 'oldrel-2'}
-          - {os: ubuntu-18.04,   r: 'oldrel-3'}
-          #- {os: ubuntu-18.04,   r: 'oldrel-4'}
+          - {os: ubuntu-latest,   r: 'devel', http-user-agent: 'release'}
+          - {os: ubuntu-latest,   r: 'release'}
+          - {os: ubuntu-latest,   r: 'oldrel-1'}
 
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
       R_KEEP_PKG_SOURCE: yes
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - uses: r-lib/actions/setup-pandoc@v2
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,12 +1,18 @@
 # labelled (development version)
 
+**Improvements**
+
 * `set_value_labels()`, `add_value_labels()`, `remove_value_labels()`,
   `set_variable_labels()`, `set_na_range()` and `set_na_values()` can now be 
   applied on a vector (#126)
 * new argument `null_action` for `var_label()` when applied on a data frame
   (#131)
 * `look_for()` now returns `"missing"` (number of `NA`s) by default (#133)
+
+**Bug fixes**
+
 * bug fix in `print.look_for()` (#135)
+* bug fix in `unlabelled()` for classic vectors, now remained unchanged (#137)
 
 # labelled 2.10.0
 

--- a/R/to_factor.R
+++ b/R/to_factor.R
@@ -250,6 +250,8 @@ to_factor.data.frame <- function(
 unlabelled <- function(x, ...) {
   if (is.data.frame(x))
     to_factor(x, strict = TRUE, unclass = TRUE, labelled_only = TRUE, ...)
-  else
+  else if (inherits(x, "haven_labelled"))
     to_factor(x, strict = TRUE, unclass = TRUE, ...)
+  else
+    x
 }

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ state and is being actively
 developed.](https://www.repostatus.org/badges/0.1.0/active.svg)](https://www.repostatus.org/#active)
 [![Lifecycle:
 stable](https://img.shields.io/badge/lifecycle-stable-brightgreen.svg)](https://lifecycle.r-lib.org/articles/stages.html#stable)
-[![R build status](https://github.com/larmarange/labelled/workflows/R-CMD-check/badge.svg)](https://github.com/larmarange/labelled/actions)
+[![R-CMD-check](https://github.com/larmarange/labelled/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/larmarange/labelled/actions/workflows/R-CMD-check.yaml)
 [![CRAN\_Status\_Badge](https://www.r-pkg.org/badges/version/labelled)](https://cran.r-project.org/package=labelled)
 [![Downloads](https://cranlogs.r-pkg.org/badges/labelled)](https://cran.r-project.org/package=labelled)
 [![DOI](https://www.zenodo.org/badge/38772078.svg)](https://www.zenodo.org/badge/latestdoi/38772078)

--- a/tests/testthat/test-labelled.r
+++ b/tests/testthat/test-labelled.r
@@ -978,6 +978,8 @@ test_that("unlabelled works correctly", {
 
   v <- labelled(c(1, 1, 2, 3), labels = c(No = 1, Yes = 2))
   expect_false(inherits(unlabelled(v), "haven_labelled"))
+
+  expect_false(is.factor(unlabelled(1:4)))
 })
 
 # remove_label ------------------------------------------


### PR DESCRIPTION
fix #137