### PR TITLE
fix in `recode.haven_labelled()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,8 @@
 
 * avoid an error with `print.look_for()` when console pane is physically shrunk
   too small (#148)
+* fix in `recode.haven_labelled()` when `.x` contains `NA` and
+  `.combine_value_labels = TRUE` (#151)
 
 # labelled 2.12.0
 

--- a/R/recode.R
+++ b/R/recode.R
@@ -97,10 +97,10 @@ recode.haven_labelled <- function(
     if (.combine_value_labels) {
       ret <- copy_labels(.x, ret)
 
-      old_vals <- unique(.x)
+      old_vals <- unique(.x) %>% na.omit()
       new_vals <- c()
       for (o in old_vals) {
-        new_vals <- c(new_vals, ret[.x == o][1])
+        new_vals <- c(new_vals, ret[!is.na(.x) & .x == o][1])
       }
 
       original_labels <- val_labels(.x)

--- a/tests/testthat/test-labelled.r
+++ b/tests/testthat/test-labelled.r
@@ -896,6 +896,10 @@ test_that("dplyr::recode could handle NA with .combine_value_labels", {
   x <- labelled(c(NA, 1:3), c(yes = 1, maybe = 2, no = 3))
   y <- x %>% dplyr::recode(`2` = 0L, .combine_value_labels = TRUE)
   expect_true(all(c(0, 1, 3) %in% val_labels(y)))
+
+  y <- x %>% dplyr::recode(`2` = 0L, `3` = 0L, .combine_value_labels = TRUE)
+  expect_true(all(c(0, 1) %in% val_labels(y)))
+  expect_equal(val_label(y, 0), "maybe / no")
 })
 
 

--- a/tests/testthat/test-labelled.r
+++ b/tests/testthat/test-labelled.r
@@ -892,6 +892,13 @@ test_that("dplyr::recode could be applied to character labelled vector", {
   expect_equal(x, labelled(c("a", "b", "b"), c(yes = "a", no = "b")))
 })
 
+test_that("dplyr::recode could handle NA with .combine_value_labels", {
+  x <- labelled(c(NA, 1:3), c(yes = 1, maybe = 2, no = 3))
+  y <- x %>% dplyr::recode(`2` = 0L, .combine_value_labels = TRUE)
+  expect_true(all(c(0, 1, 3) %in% val_labels(y)))
+})
+
+
 # update_labelled ----------------------------------------
 
 test_that("update_labelled update previous haven's labelled objects but not Hmisc's labelled objects", { # nolint


### PR DESCRIPTION
when `.x` contains `NA` and `.combine_value_labels = TRUE`

fix #151