### PR TITLE
improve package index, remove mention of dplyr::data_frame, improve reference index, link vignette from docs

### DIFF
--- a/R/lookfor.R
+++ b/R/lookfor.R
@@ -25,6 +25,7 @@
 #' @param x a tibble returned by `look_for()`
 #' @return a tibble data frame featuring the variable position, name and
 #' description (if it exists) in the original data frame
+#' @seealso `vignette("look_for")`
 #' @details The function looks into the variable names for matches to the
 #' keywords. If available, variable labels are included in the search scope.
 #' Variable labels of data.frame imported with \pkg{foreign} or

--- a/R/recode.R
+++ b/R/recode.R
@@ -5,9 +5,9 @@
 #'
 #' @importFrom dplyr recode
 #' @inheritParams dplyr::recode
-#' @param .keep_value_labels If TRUE, keep original value labels.
-#'   If FALSE, remove value labels.
-#' @param .combine_value_labels If TRUE, will combine original value labels
+#' @param .keep_value_labels If `TRUE`, keep original value labels.
+#'   If `FALSE`, remove value labels.
+#' @param .combine_value_labels If `TRUE`, will combine original value labels
 #'   to generate new value labels. Note that unexpected results could be
 #'   obtained if a same old value is recoded into several different new values.
 #' @param .sep Separator to be used when combining value labels.

--- a/R/to_labelled.R
+++ b/R/to_labelled.R
@@ -206,8 +206,8 @@ memisc_to_labelled <- function(x) {
 #'   codes
 #' @details
 #' If you convert a labelled vector into a factor with prefix, i.e. by using
-#' [`to_factor(levels = "prefixed")`[to_factor()], `to_labelled.factor()` is able
-#' to reconvert it to a labelled vector with same values and labels.
+#' [`to_factor(levels = "prefixed")`][to_factor()], `to_labelled.factor()` is
+#' able to reconvert it to a labelled vector with same values and labels.
 #' @export
 #' @examples
 #' # Converting factors to labelled vectors

--- a/R/to_labelled.R
+++ b/R/to_labelled.R
@@ -206,7 +206,7 @@ memisc_to_labelled <- function(x) {
 #'   codes
 #' @details
 #' If you convert a labelled vector into a factor with prefix, i.e. by using
-#' [to_factor(levels = "prefixed")][to_factor()], `to_labelled.factor()` is able
+#' [`to_factor(levels = "prefixed")`[to_factor()], `to_labelled.factor()` is able
 #' to reconvert it to a labelled vector with same values and labels.
 #' @export
 #' @examples

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -24,7 +24,7 @@ reference:
 - title: Manipulating value labels
   desc:  Functions to set, manipulate and remove value labels
   contents:
-  - labelled
+  - haven::labelled
   - val_label
   - remove_var_label
   - sort_val_labels
@@ -34,19 +34,19 @@ reference:
   - copy_labels
   - update_variable_labels_with
 - title: Data dictionary
-  desc:  Functions to look for keywords variable names / labels and create a data dictionary
+  desc:  Functions to look for keywords variable names / labels and create a data dictionary.
   contents:
   - look_for
 - title: Manipulating SPSS style missing values
   desc:  Functions to set, manipulate and remove SPSS style missing values
   contents:
-  - labelled_spss
+  - haven::labelled_spss
   - na_values
   - copy_labels
   - remove_user_na
 - title: Tagged missing values
   contents:
-  - tagged_na
+  - haven::tagged_na
   - unique_tagged_na
   - tagged_na_to_user_na
 - title: Converting

--- a/man/look_for.Rd
+++ b/man/look_for.Rd
@@ -175,6 +175,9 @@ d \%>\%
   lookfor_to_long_format() \%>\%
   convert_list_columns_to_character()
 }
+\seealso{
+\code{vignette("look_for")}
+}
 \author{
 François Briatte \href{mailto:f.briatte@gmail.com}{f.briatte@gmail.com},
 Joseph Larmarange \href{mailto:joseph@larmarange.net}{joseph@larmarange.net}

--- a/man/recode.haven_labelled.Rd
+++ b/man/recode.haven_labelled.Rd
@@ -41,10 +41,10 @@ are not compatible, unmatched values are replaced with \code{NA}.
 replaced by this value. Must be either length 1 or the same length as
 \code{.x}.}
 
-\item{.keep_value_labels}{If TRUE, keep original value labels.
-If FALSE, remove value labels.}
+\item{.keep_value_labels}{If \code{TRUE}, keep original value labels.
+If \code{FALSE}, remove value labels.}
 
-\item{.combine_value_labels}{If TRUE, will combine original value labels
+\item{.combine_value_labels}{If \code{TRUE}, will combine original value labels
 to generate new value labels. Note that unexpected results could be
 obtained if a same old value is recoded into several different new values.}
 

--- a/man/to_labelled.Rd
+++ b/man/to_labelled.Rd
@@ -70,7 +70,7 @@ So far, missing values defined in \strong{Stata} are always imported as \code{NA
 \code{\link[foreign:read.dta]{foreign::read.dta()}} and could not be retrieved by \code{foreign_to_labelled()}.
 
 If you convert a labelled vector into a factor with prefix, i.e. by using
-\link[=to_factor]{to_factor(levels = "prefixed")}, \code{to_labelled.factor()} is able
+[\code{to_factor(levels = "prefixed")}\code{\link[=to_factor]{to_factor()}}, \code{to_labelled.factor()} is able
 to reconvert it to a labelled vector with same values and labels.
 }
 \examples{

--- a/man/to_labelled.Rd
+++ b/man/to_labelled.Rd
@@ -70,8 +70,8 @@ So far, missing values defined in \strong{Stata} are always imported as \code{NA
 \code{\link[foreign:read.dta]{foreign::read.dta()}} and could not be retrieved by \code{foreign_to_labelled()}.
 
 If you convert a labelled vector into a factor with prefix, i.e. by using
-[\code{to_factor(levels = "prefixed")}\code{\link[=to_factor]{to_factor()}}, \code{to_labelled.factor()} is able
-to reconvert it to a labelled vector with same values and labels.
+\code{\link[=to_factor]{to_factor(levels = "prefixed")}}, \code{to_labelled.factor()} is
+able to reconvert it to a labelled vector with same values and labels.
 }
 \examples{
 \dontrun{

--- a/vignettes/labelled.Rmd
+++ b/vignettes/labelled.Rmd
@@ -491,7 +491,7 @@ If you are using the `%>%` operator, you can use the functions `set_variable_lab
 ```{r}
 library(dplyr)
 
-df <- data_frame(s1 = c("M", "M", "F"), s2 = c(1, 1, 2)) %>%
+df <- tibble(s1 = c("M", "M", "F"), s2 = c(1, 1, 2)) %>%
   set_variable_labels(s1 = "Sex", s2 = "Question") %>%
   set_value_labels(s1 = c(Male = "M", Female = "F"), s2 = c(Yes = 1, No = 2))
 df$s2


### PR DESCRIPTION
I just noted the use of `dplyr::data_frame()` in vignette and squeezed in minor improvements notably to the package index to avoid listing all re-exports, I included a link to the specific topic in haven instead.