### PR TITLE
Update `val_labels<-.data.frame` to address issue #192

### DIFF
--- a/.lintr
+++ b/.lintr
@@ -1,4 +1,4 @@
-linters: linters_with_defaults(object_name_linter=NULL, object_length_linter=NULL, object_usage_linter = NULL) # see vignette("lintr")
+linters: linters_with_defaults(object_name_linter=NULL, object_length_linter=NULL, object_usage_linter = NULL, pipe_consistency_linter=NULL) # see vignette("lintr")
 encoding: "UTF-8"
 exclusions: list(
     "R/import-standalone-obj-type.R",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,10 @@
 # labelled (development version)
 
+**Bug fix**
+
+* `value_labels()` works on empty vector, i.e. a logical vector containing
+  only `NA` values (#192)
+
 # labelled 2.16.0
 
 **New features**

--- a/R/val_labels.R
+++ b/R/val_labels.R
@@ -191,11 +191,16 @@ val_labels.svyrep.design <- val_labels.survey.design
 
   for (var in names(value)) {
     if (!is.null(value[[var]])) {
-      if (mode(x[[var]]) != mode(value[[var]]))
-        cli::cli_abort(paste(
-          "{.arg x} ({class(x)}) and {.arg value} ({class(value)})",
-          "must be same type."
-        ))
+      if (mode(x[[var]]) != mode(value[[var]])) {
+        if (all(is.na(x[[var]]))) {
+          mode(x[[var]]) <- mode(value[[var]])
+        } else {
+          cli::cli_abort(paste(
+            "{.arg x} ({mode(x[[var]])}) and {.arg value} ({mode(value[[var]])})",
+            "must be same type."
+          ))
+        }
+      }
       if (typeof(x[[var]]) != typeof(value[[var]])) {
         mode(value[[var]]) <- typeof(x[[var]])
       }

--- a/R/val_labels.R
+++ b/R/val_labels.R
@@ -195,10 +195,7 @@ val_labels.svyrep.design <- val_labels.survey.design
         if (all(is.na(x[[var]]))) {
           mode(x[[var]]) <- mode(value[[var]])
         } else {
-          cli::cli_abort(paste(
-            "{.arg x} ({mode(x[[var]])}) and {.arg value} ({mode(value[[var]])})",
-            "must be same type."
-          ))
+          cli::cli_abort(paste("{.var x[[{.str {var}}]]} ({.cls {mode(x[[var]])}}) and {.var value[[{.str {var}}]]} ({.cls {mode(value[[var]])}})", "must be same type."))
         }
       }
       if (typeof(x[[var]]) != typeof(value[[var]])) {

--- a/R/val_labels.R
+++ b/R/val_labels.R
@@ -79,6 +79,13 @@ val_labels.svyrep.design <- val_labels.survey.design
     value) {
   null_action <- match.arg(null_action)
   if (!is.null(value) || null_action == "labelled") {
+    if (!is.null(value) && all(is.na(x)) && mode(x) != mode(value)) {
+      cli::cli_warn(c(
+              "Vectors must be same type.",
+        "i" = "Converted {.var x} from {.cls {mode(x)}} to {.cls {mode(value)}}."
+      ))
+      mode(x) <- mode(value)
+    }
     x <- labelled(x, value, label = var_label(x))
   }
   # otherwise do nothing
@@ -192,10 +199,21 @@ val_labels.svyrep.design <- val_labels.survey.design
   for (var in names(value)) {
     if (!is.null(value[[var]])) {
       if (mode(x[[var]]) != mode(value[[var]])) {
-        if (all(is.na(x[[var]]))) {
+        if (!is.null(value[[var]]) && all(is.na(x[[var]])) && mode(x[[var]]) != mode(value[[var]])) {
+          cli::cli_warn(c(
+            "Vectors must be same type.",
+            "i" = "Converted {.var x[[{.str {var}}]]} from {.cls {mode(x[[var]])}} to {.cls {mode(value[[var]])}}."
+          ))
           mode(x[[var]]) <- mode(value[[var]])
         } else {
-          cli::cli_abort(paste("{.var x[[{.str {var}}]]} ({.cls {mode(x[[var]])}}) and {.var value[[{.str {var}}]]} ({.cls {mode(value[[var]])}})", "must be same type."))
+          cli::cli_abort(c(
+            "Vectors must be same type.",
+            "x" = paste(
+              "{.var x[[{.str {var}}]]} is {.cls {mode(x[[var]])}}",
+              "but",
+              "{.var value[[{.str {var}}]]} is {.cls {mode(value[[var]])}}."
+            )
+          ))
         }
       }
       if (typeof(x[[var]]) != typeof(value[[var]])) {

--- a/R/val_labels.R
+++ b/R/val_labels.R
@@ -80,10 +80,13 @@ val_labels.svyrep.design <- val_labels.survey.design
   null_action <- match.arg(null_action)
   if (!is.null(value) || null_action == "labelled") {
     if (!is.null(value) && all(is.na(x)) && mode(x) != mode(value)) {
-      cli::cli_warn(c(
-              "Vectors must be same type.",
-        "i" = "Converted {.var x} from {.cls {mode(x)}} to {.cls {mode(value)}}."
-      ))
+      cli::cli_alert_info(
+        c(
+          "Vectors must be same type. ",
+          "i" =
+            "Converted {.var x} from {.cls {mode(x)}} to {.cls {mode(value)}}."
+        )
+      )
       mode(x) <- mode(value)
     }
     x <- labelled(x, value, label = var_label(x))
@@ -104,10 +107,13 @@ val_labels.svyrep.design <- val_labels.survey.design
 
 #' @export
 `val_labels<-.numeric` <- function(
-    x,
-    null_action = c("unclass", "labelled"),
-    value) {
+  x,
+  null_action = c("unclass", "labelled"),
+  value
+) {
   null_action <- match.arg(null_action)
+  if (!is.null(value) && !is.numeric(value))
+    cli::cli_abort("{.arg x} and {.arg value} should be same type.")
   if ((!is.null(value) && length(value) > 0) || null_action == "labelled") {
     x <- labelled(x, value, label = var_label(x))
   }
@@ -116,10 +122,13 @@ val_labels.svyrep.design <- val_labels.survey.design
 
 #' @export
 `val_labels<-.character` <- function(
-    x,
-    null_action = c("unclass", "labelled"),
-    value) {
+  x,
+  null_action = c("unclass", "labelled"),
+  value
+) {
   null_action <- match.arg(null_action)
+  if (!is.null(value) && !is.character(value))
+    cli::cli_abort("{.arg x} and {.arg value} should be same type.")
   if ((!is.null(value) && length(value) > 0) || null_action == "labelled") {
     x <- labelled(x, value, label = var_label(x))
   }
@@ -199,15 +208,18 @@ val_labels.svyrep.design <- val_labels.survey.design
   for (var in names(value)) {
     if (!is.null(value[[var]])) {
       if (mode(x[[var]]) != mode(value[[var]])) {
-        if (!is.null(value[[var]]) && all(is.na(x[[var]])) && mode(x[[var]]) != mode(value[[var]])) {
-          cli::cli_warn(c(
-            "Vectors must be same type.",
-            "i" = "Converted {.var x[[{.str {var}}]]} from {.cls {mode(x[[var]])}} to {.cls {mode(value[[var]])}}."
+        if (all(is.na(x[[var]]))) {
+          cli::cli_alert_info(c(
+            "Vectors must be same type. ",
+            "i" = paste(
+              "Converted {.var x${var}} from {.cls {mode(x[[var]])}}",
+              "to {.cls {mode(value[[var]])}}."
+            )
           ))
           mode(x[[var]]) <- mode(value[[var]])
         } else {
           cli::cli_abort(c(
-            "Vectors must be same type.",
+            "Vectors must be same type. ",
             "x" = paste(
               "{.var x[[{.str {var}}]]} is {.cls {mode(x[[var]])}}",
               "but",

--- a/tests/testthat/test-labelled.r
+++ b/tests/testthat/test-labelled.r
@@ -279,6 +279,28 @@ test_that(" 'val_labels <-'  works for dataframe", {
   expect_true(all(sapply(val_labels(df), is.null)))
 })
 
+test_that("val_labels works with all NAs vectors", {
+  x <- c(NA, NA)
+  expect_message(
+    val_labels(x) <- c(yes = 1, no = 2)
+  )
+
+  x <- c(NA, NA)
+  expect_message(
+    val_labels(x) <- c(yes = "y")
+  )
+
+  d <- data.frame(q = c(NA, NA))
+  expect_message(
+    val_labels(d) <- list(q = c(no = 1))
+  )
+
+  d <- data.frame(q = c(NA, NA))
+  expect_message(
+    d %>% set_value_labels(q = c(yes = "y"))
+  )
+})
+
 test_that("val_label works for haven_labelled", {
   v <- labelled(
     c(1, 2, 2, 2, 3, 9, 1, 3, 2, NA),


### PR DESCRIPTION
Proposed workaround solution for issue #192 where value labels fail to be assigned to completely `NA` columns in a data.frame. Now when an empty column is detected, the function will manually assign the correct mode (from the value labels vector) to the data.frame's column before proceeding with assigning value labels via `val_labels<-`; otherwise, the function will fail with a more informative error message.

The old error message did not report exactly what the problem was (e.g., logical vs. numeric vectors) or what column in the data.frame was causing the issue.