### PR TITLE
fix: set_value_labels .labels+.overwrite=FALSE bug, error msg typo, test names

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,7 @@
   only `NA` values (#192)
 * `dictionary_to_value_labels()` now handles value labels with repeated
   `delim_value_label` (#194)
+* fix in `set_value_labels()` when `.overwrite = FALSE` (#198, @ LeonidasZhak)
 
 # labelled 2.16.0
 

--- a/R/na_values.R
+++ b/R/na_values.R
@@ -120,7 +120,7 @@ na_values.svyrep.design <- na_values.survey.design
 #' @export
 `na_values<-.factor` <- function(x, value) {
   if (!is.null(value))
-    cli::cli_abort("{.fn na_values}` cannot be applied to factors.")
+    cli::cli_abort("{.fn na_values} cannot be applied to factors.")
   x %>% remove_attributes("na_values")
 }
 

--- a/R/val_labels.R
+++ b/R/val_labels.R
@@ -505,7 +505,7 @@ set_value_labels <- function(
       .labels <- .labels[intersect(names(.labels), names(.data))]
     }
     if (!.overwrite) {
-      .labels <- .labels[setdiff(already, names(.data))]
+      .labels <- .labels[setdiff(names(.labels), already)]
     }
     val_labels(.data, null_action = .null_action) <- .labels
   }

--- a/tests/testthat/test-labelled.r
+++ b/tests/testthat/test-labelled.r
@@ -468,7 +468,7 @@ test_that("remove_labels works with labelled_spss", {
 # remove_val_labels ------------------------------------------------------------
 
 
-test_that("remove_labels works properly", {
+test_that("remove_val_labels works properly", {
   var <- labelled(
     c(1L, 98L, 99L),
     c(not_answered = 98L, not_applicable = 99L),
@@ -485,7 +485,7 @@ test_that("remove_labels works properly", {
 # remove_var_label ------------------------------------------------------------
 
 
-test_that("remove_labels works properly", {
+test_that("remove_var_label works properly", {
   var <- labelled(
     c(1L, 98L, 99L),
     c(not_answered = 98L, not_applicable = 99L),
@@ -788,6 +788,26 @@ test_that("set_value_labels replaces all value labels", {
 
   v <- set_value_labels(v, NULL)
   expect_null(val_labels(v))
+})
+
+test_that("set_value_labels .labels + .overwrite = FALSE on data frames", {
+  df <- data.frame(
+    s1 = labelled(c("M", "M", "F"), c(Male = "M", Female = "F")),
+    s2 = labelled(c(1, 1, 2), c(Yes = 1, No = 2)),
+    x = 1:3,
+    stringsAsFactors = FALSE
+  )
+
+  # .labels + .overwrite = FALSE: should skip s1 and s2 (already labelled)
+  # and apply to x (unlabelled)
+  df2 <- set_value_labels(
+    df,
+    .labels = list(s1 = c(Male2 = "M"), s2 = c(Maybe = 3), x = c(low = 1)),
+    .overwrite = FALSE
+  )
+  expect_equal(val_labels(df2$s1), c(Male = "M", Female = "F"))
+  expect_equal(val_labels(df2$s2), c(Yes = 1, No = 2))
+  expect_equal(val_labels(df2$x), c(low = 1))
 })
 
 test_that("set_value_labels errors", {

--- a/tests/testthat/test-labelled.r
+++ b/tests/testthat/test-labelled.r
@@ -790,7 +790,7 @@ test_that("set_value_labels replaces all value labels", {
   expect_null(val_labels(v))
 })
 
-test_that("set_value_labels .labels + .overwrite = FALSE on data frames", {
+test_that("set_value_labels .labels + .overwrite on data frames", {
   df <- data.frame(
     s1 = labelled(c("M", "M", "F"), c(Male = "M", Female = "F")),
     s2 = labelled(c(1, 1, 2), c(Yes = 1, No = 2)),
@@ -807,6 +807,16 @@ test_that("set_value_labels .labels + .overwrite = FALSE on data frames", {
   )
   expect_equal(val_labels(df2$s1), c(Male = "M", Female = "F"))
   expect_equal(val_labels(df2$s2), c(Yes = 1, No = 2))
+  expect_equal(val_labels(df2$x), c(low = 1))
+
+  # .overwrite = TRUE
+  df2 <- set_value_labels(
+    df,
+    .labels = list(s1 = c(Male2 = "M"), s2 = c(Maybe = 3), x = c(low = 1)),
+    .overwrite = TRUE
+  )
+  expect_equal(val_labels(df2$s1), c(Male2 = "M"))
+  expect_equal(val_labels(df2$s2), c(Maybe = 3))
   expect_equal(val_labels(df2$x), c(low = 1))
 })
 


### PR DESCRIPTION
## Summary

Three focused fixes in the labelled package:

1. **Bug fix**: `set_value_labels()` with `.labels` + `.overwrite = FALSE` was using wrong `setdiff` arguments — `setdiff(already, names(.data))` instead of `setdiff(names(.labels), already)`. This meant that when `.overwrite = FALSE`, labels were not correctly filtered to exclude already-labelled variables.

2. **Error message typo**: `na_values<-.factor` had a stray backtick in the cli message: `{.fn na_values}\`` followed by ` cannot be applied to factors.` → removed the stray backtick.

3. **Test name duplication**: Two separate `test_that` blocks were both named "remove_labels works properly" — one for `remove_val_labels` and one for `remove_var_label`. Renamed to match the functions being tested.

4. **New test**: Added explicit test for `set_value_labels .labels + .overwrite = FALSE` on data frames.

## Validation

- `R CMD build .` — OK
- `R CMD check --no-manual` — OK (no new failures)
- `testthat::test_local()` — all tests pass
